### PR TITLE
Define optional metadata as having any string values

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -58,6 +58,8 @@ components:
         metadata:
           type: object
           description: The metadata from ${request.body#/completed_webhook/metadata}.
+          additionalProperties:
+            type: string
           examples:
             - user_id: 1
         endgrate:
@@ -613,6 +615,8 @@ components:
         metadata:
           type: object
           description: The metadata from ${request.body#/data_webhook/metadata}.
+          additionalProperties:
+            type: string
           examples:
             - user_id: 1
         endgrate:
@@ -904,6 +908,8 @@ components:
         metadata:
           type: object
           description: Any information to be passed back in the webhook call.
+          additionalProperties:
+            type: string
           examples:
             - user_id: 1
       required:
@@ -1572,6 +1578,8 @@ components:
         metadata:
           type: object
           description: Any information to be passed back in the webhook call.
+          additionalProperties:
+            type: string
           example:
             user_id: 1
       required:
@@ -1910,6 +1918,8 @@ paths:
                             metadata:
                               type: object
                               description: The metadata from ${request.body#/data_webhook/metadata}.
+                              additionalProperties:
+                                type: string
                               example:
                                 user_id: 1
                               
@@ -1945,6 +1955,8 @@ paths:
                             metadata:
                               type: object
                               description: The metadata from ${request.body#/error_webhook/metadata}.
+                              additionalProperties:
+                                type: string
                               example:
                                 user_id: 1
                             success:
@@ -2378,6 +2390,8 @@ paths:
                             metadata:
                               type: object
                               description: The metadata from ${request.body#/data_webhook/metadata}.
+                              additionalProperties:
+                                type: string
                               example:
                                 user_id: 1
                               
@@ -2400,6 +2414,8 @@ paths:
                             metadata:
                               type: object
                               description: The metadata from ${request.body#/error_webhook/metadata}.
+                              additionalProperties:
+                                type: string
                               example:
                                 user_id: 1
                             success:
@@ -2619,6 +2635,8 @@ paths:
                             metadata:
                               type: object
                               description: The metadata from ${request.body#/data_webhook/metadata}.
+                              additionalProperties:
+                                type: string
                               example:
                                 user_id: 1
                               
@@ -2654,6 +2672,8 @@ paths:
                             metadata:
                               type: object
                               description: The metadata from ${request.body#/error_webhook/metadata}.
+                              additionalProperties:
+                                type: string
                               example:
                                 user_id: 1
                             success:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -59,7 +59,10 @@ components:
           type: object
           description: The metadata from ${request.body#/completed_webhook/metadata}.
           additionalProperties:
-            type: string
+            type:
+              - string
+              - integer
+              - boolean
           examples:
             - user_id: 1
         endgrate:
@@ -616,7 +619,10 @@ components:
           type: object
           description: The metadata from ${request.body#/data_webhook/metadata}.
           additionalProperties:
-            type: string
+            type:
+              - string
+              - integer
+              - boolean
           examples:
             - user_id: 1
         endgrate:
@@ -909,7 +915,10 @@ components:
           type: object
           description: Any information to be passed back in the webhook call.
           additionalProperties:
-            type: string
+            type:
+              - string
+              - integer
+              - boolean
           examples:
             - user_id: 1
       required:
@@ -1579,7 +1588,10 @@ components:
           type: object
           description: Any information to be passed back in the webhook call.
           additionalProperties:
-            type: string
+            type:
+              - string
+              - integer
+              - boolean
           example:
             user_id: 1
       required:
@@ -1919,7 +1931,10 @@ paths:
                               type: object
                               description: The metadata from ${request.body#/data_webhook/metadata}.
                               additionalProperties:
-                                type: string
+                                type:
+                                  - string
+                                  - integer
+                                  - boolean
                               example:
                                 user_id: 1
                               
@@ -1956,7 +1971,10 @@ paths:
                               type: object
                               description: The metadata from ${request.body#/error_webhook/metadata}.
                               additionalProperties:
-                                type: string
+                                type:
+                                  - string
+                                  - integer
+                                  - boolean
                               example:
                                 user_id: 1
                             success:
@@ -2391,7 +2409,10 @@ paths:
                               type: object
                               description: The metadata from ${request.body#/data_webhook/metadata}.
                               additionalProperties:
-                                type: string
+                                type:
+                                  - string
+                                  - integer
+                                  - boolean
                               example:
                                 user_id: 1
                               
@@ -2415,7 +2436,10 @@ paths:
                               type: object
                               description: The metadata from ${request.body#/error_webhook/metadata}.
                               additionalProperties:
-                                type: string
+                                type:
+                                  - string
+                                  - integer
+                                  - boolean
                               example:
                                 user_id: 1
                             success:
@@ -2636,7 +2660,10 @@ paths:
                               type: object
                               description: The metadata from ${request.body#/data_webhook/metadata}.
                               additionalProperties:
-                                type: string
+                                type:
+                                  - string
+                                  - integer
+                                  - boolean
                               example:
                                 user_id: 1
                               
@@ -2673,7 +2700,10 @@ paths:
                               type: object
                               description: The metadata from ${request.body#/error_webhook/metadata}.
                               additionalProperties:
-                                type: string
+                                type:
+                                  - string
+                                  - integer
+                                  - boolean
                               example:
                                 user_id: 1
                             success:


### PR DESCRIPTION
This fixes the TypeScript type that is generated from [openapi-typescript](https://www.npmjs.com/package/openapi-typescript)

See: [OpenAPI Typescript](https://openapi-ts.pages.dev/advanced#be-specific-in-your-schema)

This changes the TypeScript definitions for the allowed `metadata` field from:

```
metadata?: Record<string, never>;
```

to:

```
metadata?: {
  [key: string]: string | number | boolean;
}
```